### PR TITLE
Extension manages the metadata update flow rather than dapps

### DIFF
--- a/packages/extension-base/src/background/handlers/Extension.ts
+++ b/packages/extension-base/src/background/handlers/Extension.ts
@@ -5,7 +5,48 @@ import type { MetadataDef } from '@polkadot/extension-inject/types';
 import type { KeyringPair, KeyringPair$Json, KeyringPair$Meta } from '@polkadot/keyring/types';
 import type { SignerPayloadJSON, SignerPayloadRaw } from '@polkadot/types/types';
 import type { SubjectInfo } from '@polkadot/ui-keyring/observable/types';
-import type { AccountJson, AllowedPath, AuthorizeRequest, MessageTypes, MetadataRequest, RequestAccountBatchExport, RequestAccountChangePassword, RequestAccountCreateExternal, RequestAccountCreateHardware, RequestAccountCreateSuri, RequestAccountEdit, RequestAccountExport, RequestAccountForget, RequestAccountShow, RequestAccountTie, RequestAccountValidate, RequestAuthorizeApprove, RequestAuthorizeReject, RequestBatchRestore, RequestDeriveCreate, RequestDeriveValidate, RequestJsonRestore, RequestMetadataApprove, RequestMetadataReject, RequestSeedCreate, RequestSeedValidate, RequestSigningApprovePassword, RequestSigningApproveSignature, RequestSigningCancel, RequestSigningIsLocked, RequestTypes, ResponseAccountExport, ResponseAuthorizeList, ResponseDeriveValidate, ResponseJsonGetAccountInfo, ResponseSeedCreate, ResponseSeedValidate, ResponseSigningIsLocked, ResponseType, SigningRequest } from '../types';
+import type {
+  AccountJson,
+  AllowedPath,
+  AuthorizeRequest,
+  MessageTypes,
+  MetadataRequest,
+  RequestAccountBatchExport,
+  RequestAccountChangePassword,
+  RequestAccountCreateExternal,
+  RequestAccountCreateHardware,
+  RequestAccountCreateSuri,
+  RequestAccountEdit,
+  RequestAccountExport,
+  RequestAccountForget,
+  RequestAccountShow,
+  RequestAccountTie,
+  RequestAccountValidate,
+  RequestAuthorizeApprove,
+  RequestAuthorizeReject,
+  RequestBatchRestore,
+  RequestDeriveCreate,
+  RequestDeriveValidate,
+  RequestJsonRestore,
+  RequestMetadataApprove,
+  RequestMetadataReject,
+  RequestSeedCreate,
+  RequestSeedValidate,
+  RequestSigningApprovePassword,
+  RequestSigningApproveSignature,
+  RequestSigningCancel,
+  RequestSigningIsLocked,
+  RequestTypes,
+  ResponseAccountExport,
+  ResponseAuthorizeList,
+  ResponseDeriveValidate,
+  ResponseJsonGetAccountInfo,
+  ResponseSeedCreate,
+  ResponseSeedValidate,
+  ResponseSigningIsLocked,
+  ResponseType,
+  SigningRequest
+} from '../types';
 
 import { ALLOWED_PATH, PASSWORD_EXPIRY_MS } from '@polkadot/extension-base/defaults';
 import chrome from '@polkadot/extension-inject/chrome';
@@ -234,6 +275,10 @@ export default class Extension {
 
   private metadataGet (genesisHash: string | null): MetadataDef | null {
     return this.#state.knownMetadata.find((result) => result.genesisHash === genesisHash) || null;
+  }
+
+  private metadataSet (def: MetadataDef) {
+    this.#state.saveMetadata(def);
   }
 
   private metadataList (): MetadataDef[] {
@@ -559,6 +604,9 @@ export default class Extension {
 
       case 'pri(metadata.get)':
         return this.metadataGet(request as string);
+
+      case 'pri(metadata.set)':
+        return this.metadataSet(request as MetadataDef);
 
       case 'pri(metadata.list)':
         return this.metadataList();

--- a/packages/extension-base/src/background/types.ts
+++ b/packages/extension-base/src/background/types.ts
@@ -98,6 +98,7 @@ export interface RequestSignatures {
   'pri(json.account.info)': [KeyringPair$Json, ResponseJsonGetAccountInfo];
   'pri(metadata.approve)': [RequestMetadataApprove, boolean];
   'pri(metadata.get)': [string | null, MetadataDef | null];
+  'pri(metadata.set)': [MetadataDef, MetadataDef | null];
   'pri(metadata.reject)': [RequestMetadataReject, boolean];
   'pri(metadata.requests)': [RequestMetadataSubscribe, boolean, MetadataRequest[]];
   'pri(metadata.list)': [null, MetadataDef[]];

--- a/packages/extension-chains/src/config.ts
+++ b/packages/extension-chains/src/config.ts
@@ -263,7 +263,7 @@ const commomTypes = {"color": "#191a2e",
 };
 const nikau = {
   "chain": "CENNZnet Nikau",
-  "genesisHash": "0x4d9337089848aa1aac7f6db23118c3844cfd99972c394521f62341ef1b657612",
+  "genesisHash": "0xc65170707265757d8a1fb8e039062286b8f0092f2984f5938588bd8e0f21ca2e",
   "specVersion": 40,
   ...commomTypes
 } as unknown as MetadataDef;
@@ -282,7 +282,7 @@ const azalea = {
 const develop = {
   "chain": "Development",
   "genesisHash": "0x43f11d7b7405d24e529d7f7b0ff65154e73eebf0f34908d936b0be3b68429daa",
-  "specVersion": 39,
+  "specVersion": 40,
   ...commomTypes
 } as unknown as MetadataDef;
 const defaultConfig = {

--- a/packages/extension-chains/src/config.ts
+++ b/packages/extension-chains/src/config.ts
@@ -279,8 +279,14 @@ const azalea = {
   "specVersion": 40,
   ...commomTypes
 } as unknown as MetadataDef;
+const develop = {
+  "chain": "Development",
+  "genesisHash": "0x43f11d7b7405d24e529d7f7b0ff65154e73eebf0f34908d936b0be3b68429daa",
+  "specVersion": 39,
+  ...commomTypes
+} as unknown as MetadataDef;
 const defaultConfig = {
-  CENNZNetChain: [nikau, rata, azalea]
+  CENNZNetChain: [nikau, rata, azalea, develop]
 };
 
 export default defaultConfig;

--- a/packages/extension-chains/src/config.ts
+++ b/packages/extension-chains/src/config.ts
@@ -281,7 +281,7 @@ const azalea = {
 } as unknown as MetadataDef;
 const develop = {
   "chain": "Development",
-  "genesisHash": "0x43f11d7b7405d24e529d7f7b0ff65154e73eebf0f34908d936b0be3b68429daa",
+  "genesisHash": "0xba29ccef64182e17dee0f9d8bbaddc69e439acdc9409149e5c409d696c14232e",
   "specVersion": 40,
   ...commomTypes
 } as unknown as MetadataDef;

--- a/packages/extension-chains/src/index.ts
+++ b/packages/extension-chains/src/index.ts
@@ -23,7 +23,7 @@ const definitions = new Map<string, MetadataDef>(
 export function getLatestMetaFromServer(genesisHashExpected: string): MetadataFetched | null {
   try {
     const xmlHttp = new XMLHttpRequest();
-    xmlHttp.open("GET", "https://raw.githubusercontent.com/cennznet/api.js/extension-releases-setup/extension-releases/metadata.json", false);
+    xmlHttp.open("GET", "https://raw.githubusercontent.com/cennznet/api.js/extension-releases-setup/extension-releases/metaCalls.json", false);
     xmlHttp.send(null);
     let response = xmlHttp.responseText;
     const metadataDetails = JSON.parse(response);

--- a/packages/extension-chains/src/index.ts
+++ b/packages/extension-chains/src/index.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { MetadataDef } from '@polkadot/extension-inject/types';
-import type {Chain, MetadataFetched, RuntimeTypes} from './types';
+import type { Chain, MetadataFetched, RuntimeTypes } from './types';
 
 import { Metadata } from '@polkadot/metadata';
 import { TypeRegistry } from '@polkadot/types';

--- a/packages/extension-chains/src/index.ts
+++ b/packages/extension-chains/src/index.ts
@@ -23,7 +23,7 @@ const definitions = new Map<string, MetadataDef>(
 export function getLatestMetaFromServer(genesisHashExpected: string): MetadataFetched | null {
   try {
     const xmlHttp = new XMLHttpRequest();
-    xmlHttp.open("GET", "https://raw.githubusercontent.com/cennznet/api.js/extension-releases-setup/extension-releases/metaCalls.json", false);
+    xmlHttp.open("GET", "https://raw.githubusercontent.com/cennznet/api.js/master/extension-releases/metaCalls.json", false);
     xmlHttp.send(null);
     let response = xmlHttp.responseText;
     const metadataDetails = JSON.parse(response);
@@ -51,7 +51,7 @@ export function getLatestMetaFromServer(genesisHashExpected: string): MetadataFe
 export function getLatestTypesFromServer(genesisHashExpected: string): RuntimeTypes | null {
   try {
     const xmlHttp = new XMLHttpRequest();
-    xmlHttp.open("GET", "https://raw.githubusercontent.com/cennznet/api.js/extension-releases-setup/extension-releases/runtimeModuleTypes.json", false);
+    xmlHttp.open("GET", "https://raw.githubusercontent.com/cennznet/api.js/master/extension-releases/runtimeModuleTypes.json", false);
     xmlHttp.send(null);
     let response = xmlHttp.responseText;
     const additionalTypes = JSON.parse(response);

--- a/packages/extension-chains/src/index.ts
+++ b/packages/extension-chains/src/index.ts
@@ -23,8 +23,7 @@ const definitions = new Map<string, MetadataDef>(
 export function getLatestMetaFromServer(genesisHashExpected: string): MetadataFetched | null {
   try {
     const xmlHttp = new XMLHttpRequest();
-    //xmlHttp.open( "GET", "https://raw.githubusercontent.com/cennznet/api.js/master/packages/api/src/staticMetadata.ts", false ); // false for synchronous request
-    xmlHttp.open("GET", "https://raw.githubusercontent.com/cennznet/api.js/test1/extension-releases/metadata.json", false);
+    xmlHttp.open("GET", "https://raw.githubusercontent.com/cennznet/api.js/master/extension-releases/metadata.json", false);
     xmlHttp.send(null);
     let response = xmlHttp.responseText;
     const metadataDetails = JSON.parse(response);
@@ -52,8 +51,7 @@ export function getLatestMetaFromServer(genesisHashExpected: string): MetadataFe
 export function getLatestTypesFromServer(): RuntimeTypes | null {
   try {
     const xmlHttp = new XMLHttpRequest();
-    //xmlHttp.open( "GET", "https://raw.githubusercontent.com/cennznet/api.js/master/packages/api/src/staticMetadata.ts", false ); // false for synchronous request
-    xmlHttp.open("GET", "https://raw.githubusercontent.com/cennznet/api.js/test1/extension-releases/runtimeModuleTypes.json", false);
+    xmlHttp.open("GET", "https://raw.githubusercontent.com/cennznet/api.js/master/extension-releases/runtimeModuleTypes.json", false);
     xmlHttp.send(null);
     let response = xmlHttp.responseText;
     const additionalTypes = JSON.parse(response);

--- a/packages/extension-chains/src/index.ts
+++ b/packages/extension-chains/src/index.ts
@@ -19,44 +19,24 @@ const definitions = new Map<string, MetadataDef>(
 
 export function getLatestMetaFromServer(genesisHashExpected: string) {
   const xmlHttp = new XMLHttpRequest();
-//xmlHttp.open( "GET", "https://raw.githubusercontent.com/cennznet/api.js/master/packages/api/src/staticMetadata.ts", false ); // false for synchronous request
-  xmlHttp.open("GET", "https://raw.githubusercontent.com/cennznet/api.js/test1/packages/api/src/staticMetadata.ts", false);
+  //xmlHttp.open( "GET", "https://raw.githubusercontent.com/cennznet/api.js/master/packages/api/src/staticMetadata.ts", false ); // false for synchronous request
+  xmlHttp.open("GET", "https://raw.githubusercontent.com/cennznet/api.js/test1/extension-releases/metadata.json", false);
   xmlHttp.send( null );
   let response = xmlHttp.responseText;
-// Replace all the unwanted stuff and make response a json object
-  response = response.replace('export default ','');
-  response = response.replace(',\n\};','}');
-  const searchRegExp = /\'/g;
-  const replaceWith = '"';
-  response = response.replace(searchRegExp, replaceWith);
-  const staticMetadata = JSON.parse(response);
-  const key = Object.keys(staticMetadata).filter(v => v.includes(genesisHashExpected));
-  if (!key[0]) {
-    return null;
+  const metadataDetails = JSON.parse(response);
+  const metaCallsList = metadataDetails?.metaCalls;
+  const types = metadataDetails ? metadataDetails.types : {};
+  if (metaCallsList) {
+    // metaCalls is { genesisHash-specVersion: metaCalls }
+    const key = Object.keys(metaCallsList).filter(v => v.includes(genesisHashExpected));
+    if (!key[0]) {
+      return null;
+    }
+    const [, specVersion] = key[0].split('-');
+    const metaCalls = metaCallsList[key[0]];
+    return {metaCalls, specVersion: parseInt(specVersion), types};
   }
-  const [, specVersion] = key[0].split('-');
-  const metaInHex = staticMetadata[key[0]];
-  const registry = new TypeRegistry();
-  const metaFetched = new Metadata(registry, metaInHex);
-  const metaCalls = Buffer.from(metaFetched.asCallsOnly.toU8a()).toString('base64');
-  return {metaCalls, specVersion: parseInt(specVersion)};
-}
-
-
-export function getLatestTypesFromServer() {
-  try {
-    const xmlHttp = new XMLHttpRequest();
-//xmlHttp.open( "GET", "https://raw.githubusercontent.com/cennznet/api.js/master/packages/types/src/runtimeModuleTypes.ts", false ); // false for synchronous request
-    xmlHttp.open("GET", "https://raw.githubusercontent.com/cennznet/api.js/test1/packages/types/src/runtimeModuleTypes.ts", false);
-    xmlHttp.send(null);
-    let response = xmlHttp.responseText;
-// Replace all the unwanted stuff and make response a json object
-    response = response.replace('export default ', '');
-    const typesAdded = JSON.parse(response);
-    return typesAdded;
-  } catch (e) {
-    return {};
-  }
+  return null;
 }
 
 const expanded = new Map<string, Chain>();

--- a/packages/extension-chains/src/index.ts
+++ b/packages/extension-chains/src/index.ts
@@ -23,7 +23,7 @@ const definitions = new Map<string, MetadataDef>(
 export function getLatestMetaFromServer(genesisHashExpected: string): MetadataFetched | null {
   try {
     const xmlHttp = new XMLHttpRequest();
-    xmlHttp.open("GET", "https://raw.githubusercontent.com/cennznet/api.js/master/extension-releases/metadata.json", false);
+    xmlHttp.open("GET", "https://raw.githubusercontent.com/cennznet/api.js/extension-releases-setup/extension-releases/metadata.json", false);
     xmlHttp.send(null);
     let response = xmlHttp.responseText;
     const metadataDetails = JSON.parse(response);
@@ -48,16 +48,17 @@ export function getLatestMetaFromServer(genesisHashExpected: string): MetadataFe
 /** when types stored in extension is outdated
  * get the types for @cennznet/api/extension-releases
  * for cennznet specific chains **/
-export function getLatestTypesFromServer(): RuntimeTypes | null {
+export function getLatestTypesFromServer(genesisHashExpected: string): RuntimeTypes | null {
   try {
     const xmlHttp = new XMLHttpRequest();
-    xmlHttp.open("GET", "https://raw.githubusercontent.com/cennznet/api.js/master/extension-releases/runtimeModuleTypes.json", false);
+    xmlHttp.open("GET", "https://raw.githubusercontent.com/cennznet/api.js/extension-releases-setup/extension-releases/runtimeModuleTypes.json", false);
     xmlHttp.send(null);
     let response = xmlHttp.responseText;
     const additionalTypes = JSON.parse(response);
-    if (additionalTypes) {
-      const types = additionalTypes.types;
-      const userExtensions = additionalTypes.userExtensions;
+    const typesForCurrentChain = additionalTypes[genesisHashExpected];
+    if (typesForCurrentChain) {
+      const types = typesForCurrentChain.types;
+      const userExtensions = typesForCurrentChain.userExtensions;
       return {types, userExtensions};
     }
     return null;

--- a/packages/extension-chains/src/index.ts
+++ b/packages/extension-chains/src/index.ts
@@ -18,25 +18,30 @@ const definitions = new Map<string, MetadataDef>(
 );
 
 export function getLatestMetaFromServer(genesisHashExpected: string) {
-  const xmlHttp = new XMLHttpRequest();
-  //xmlHttp.open( "GET", "https://raw.githubusercontent.com/cennznet/api.js/master/packages/api/src/staticMetadata.ts", false ); // false for synchronous request
-  xmlHttp.open("GET", "https://raw.githubusercontent.com/cennznet/api.js/test1/extension-releases/metadata.json", false);
-  xmlHttp.send( null );
-  let response = xmlHttp.responseText;
-  const metadataDetails = JSON.parse(response);
-  const metaCallsList = metadataDetails?.metaCalls;
-  const types = metadataDetails ? metadataDetails.types : {};
-  if (metaCallsList) {
-    // metaCalls is { genesisHash-specVersion: metaCalls }
-    const key = Object.keys(metaCallsList).filter(v => v.includes(genesisHashExpected));
-    if (!key[0]) {
-      return null;
+  try {
+    const xmlHttp = new XMLHttpRequest();
+    //xmlHttp.open( "GET", "https://raw.githubusercontent.com/cennznet/api.js/master/packages/api/src/staticMetadata.ts", false ); // false for synchronous request
+    xmlHttp.open("GET", "https://raw.githubusercontent.com/cennznet/api.js/test1/extension-releases/metadata.json", false);
+    xmlHttp.send(null);
+    let response = xmlHttp.responseText;
+    const metadataDetails = JSON.parse(response);
+    const metaCallsList = metadataDetails?.metaCalls;
+    const types = metadataDetails ? metadataDetails.types : {};
+    if (metaCallsList) {
+      // metaCalls is { genesisHash-specVersion: metaCalls }
+      const key = Object.keys(metaCallsList).filter(v => v.includes(genesisHashExpected));
+      if (!key[0]) {
+        return null;
+      }
+      const [, specVersion] = key[0].split('-');
+      const metaCalls = metaCallsList[key[0]];
+      return {metaCalls, specVersion: parseInt(specVersion), types};
     }
-    const [, specVersion] = key[0].split('-');
-    const metaCalls = metaCallsList[key[0]];
-    return {metaCalls, specVersion: parseInt(specVersion), types};
+    return null;
+  } catch (e) {
+    console.log('Err:',e);
+    return null;
   }
-  return null;
 }
 
 const expanded = new Map<string, Chain>();

--- a/packages/extension-chains/src/types.ts
+++ b/packages/extension-chains/src/types.ts
@@ -1,6 +1,6 @@
 // Copyright 2019-2021 @polkadot/extension-chains authors & contributors
 // SPDX-License-Identifier: Apache-2.0
-
+import type { ExtDef } from '@polkadot/types/extrinsic/signedExtensions/types';
 import type { MetadataDef } from '@polkadot/extension-inject/types';
 import type { Registry } from '@polkadot/types/types';
 
@@ -16,4 +16,14 @@ export interface Chain {
   ss58Format: number;
   tokenDecimals: number;
   tokenSymbol: string;
+}
+
+export interface MetadataFetched {
+  metaCalls: string,
+  specVersion: number
+}
+
+export interface RuntimeTypes {
+  types: Record<string, Record<string, string> | string>,
+  userExtensions?: ExtDef
 }

--- a/packages/extension-ui/src/Popup/Signing/Extrinsic.tsx
+++ b/packages/extension-ui/src/Popup/Signing/Extrinsic.tsx
@@ -109,8 +109,8 @@ function mortalityAsString (era: ExtrinsicEra, hexBlockNumber: string, t: TFunct
 
 function Extrinsic ({ className, payload: { era, nonce, tip }, request: { blockNumber, genesisHash, method, specVersion: hexSpec }, url }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
-  const chain = useMetadata(genesisHash);
   const specVersion = useRef(bnToBn(hexSpec)).current;
+  const chain = useMetadata(genesisHash, specVersion);
   const decoded = useMemo(
     () => chain && chain.hasMetadata
       ? decodeMethod(method, chain, specVersion)

--- a/packages/extension-ui/src/components/Address.tsx
+++ b/packages/extension-ui/src/components/Address.tsx
@@ -98,7 +98,7 @@ function Address ({ actions, address, children, className, genesisHash, isExtern
   const { accounts } = useContext(AccountContext);
   const settings = useContext(SettingsContext);
   const [{ account, formatted, genesisHash: recodedGenesis, prefix }, setRecoded] = useState<Recoded>(defaultRecoded);
-  const chain = useMetadata(genesisHash || recodedGenesis, true);
+  const chain = useMetadata(genesisHash || recodedGenesis, null,true);
   const [showActionsMenu, setShowActionsMenu] = useState(false);
   const [moveMenuUp, setIsMovedMenu] = useState(false);
   const actionsRef = useRef<HTMLDivElement>(null);

--- a/packages/extension-ui/src/components/Address.tsx
+++ b/packages/extension-ui/src/components/Address.tsx
@@ -98,7 +98,7 @@ function Address ({ actions, address, children, className, genesisHash, isExtern
   const { accounts } = useContext(AccountContext);
   const settings = useContext(SettingsContext);
   const [{ account, formatted, genesisHash: recodedGenesis, prefix }, setRecoded] = useState<Recoded>(defaultRecoded);
-  const chain = useMetadata(genesisHash || recodedGenesis, null,true);
+  const chain = useMetadata(genesisHash || recodedGenesis, null, true);
   const [showActionsMenu, setShowActionsMenu] = useState(false);
   const [moveMenuUp, setIsMovedMenu] = useState(false);
   const actionsRef = useRef<HTMLDivElement>(null);

--- a/packages/extension-ui/src/hooks/useMetadata.ts
+++ b/packages/extension-ui/src/hooks/useMetadata.ts
@@ -6,7 +6,7 @@ import type { Chain } from '@polkadot/extension-chains/types';
 import { useEffect, useState } from 'react';
 
 import { getMetadata } from '../messaging';
-import BN from "bn.js";
+import BN from 'bn.js';
 
 export default function useMetadata (genesisHash?: string | null, specVersion?: BN | null, isPartial?: boolean): Chain | null {
   const [chain, setChain] = useState<Chain | null>(null);

--- a/packages/extension-ui/src/hooks/useMetadata.ts
+++ b/packages/extension-ui/src/hooks/useMetadata.ts
@@ -6,13 +6,14 @@ import type { Chain } from '@polkadot/extension-chains/types';
 import { useEffect, useState } from 'react';
 
 import { getMetadata } from '../messaging';
+import BN from "bn.js";
 
-export default function useMetadata (genesisHash?: string | null, isPartial?: boolean): Chain | null {
+export default function useMetadata (genesisHash?: string | null, specVersion?: BN | null, isPartial?: boolean): Chain | null {
   const [chain, setChain] = useState<Chain | null>(null);
 
   useEffect((): void => {
     if (genesisHash) {
-      getMetadata(genesisHash, isPartial)
+      getMetadata(genesisHash, specVersion, isPartial)
         .then(setChain)
         .catch((error): void => {
           console.error(error);

--- a/packages/extension-ui/src/messaging.ts
+++ b/packages/extension-ui/src/messaging.ts
@@ -165,8 +165,8 @@ export async function getMetadata (genesisHash?: string | null, specVersion?: BN
         def.metaCalls = metaDataInfo.metaCalls;
         const oldTypes = def.types;
         def.types = {...oldTypes, ...newTypes};
+        await sendMessage('pri(metadata.set)', def);
       }
-      await sendMessage('pri(metadata.set)', def);
     }
     return metadataExpand(def, isPartial);
   } else if (isPartial) {

--- a/packages/extension-ui/src/messaging.ts
+++ b/packages/extension-ui/src/messaging.ts
@@ -9,12 +9,13 @@ import type { KeyringPairs$Json } from '@polkadot/ui-keyring/types';
 import type { KeypairType } from '@polkadot/util-crypto/types';
 
 import { PORT_EXTENSION } from '@polkadot/extension-base/defaults';
-import { metadataExpand } from '@polkadot/extension-chains';
+import {getLatestMetaFromServer, getLatestTypesFromServer, metadataExpand} from '@polkadot/extension-chains';
 import chrome from '@polkadot/extension-inject/chrome';
 import { MetadataDef } from '@polkadot/extension-inject/types';
 
 import allChains from './util/chains';
 import { getSavedMeta, setSavedMeta } from './MetadataCache';
+import BN from "bn.js";
 
 interface Handler {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -139,7 +140,7 @@ export async function getAllMetatdata (): Promise<MetadataDef[]> {
   return sendMessage('pri(metadata.list)');
 }
 
-export async function getMetadata (genesisHash?: string | null, isPartial = false): Promise<Chain | null> {
+export async function getMetadata (genesisHash?: string | null, specVersion?: BN | null, isPartial = false): Promise<Chain | null> {
   if (!genesisHash) {
     return null;
   }
@@ -152,8 +153,21 @@ export async function getMetadata (genesisHash?: string | null, isPartial = fals
   }
 
   const def = await request;
-
   if (def) {
+    const specVersionInState = def.specVersion;
+    // when spec version is not the latest, fetch latest and updated state with latest metadata
+    if (specVersion && !specVersion.eqn(specVersionInState)) {
+      console.log('Spec versions are different - update meta')
+      const metaDataInfo = getLatestMetaFromServer(genesisHash);
+      const newTypes = getLatestTypesFromServer();
+      if (metaDataInfo) {
+        def.specVersion = metaDataInfo.specVersion;
+        def.metaCalls = metaDataInfo.metaCalls;
+        const oldTypes = def.types;
+        def.types = {...oldTypes, ...newTypes};
+      }
+      await sendMessage('pri(metadata.set)', def);
+    }
     return metadataExpand(def, isPartial);
   } else if (isPartial) {
     const chain = allChains.find((chain) => chain.genesisHash === genesisHash);

--- a/packages/extension-ui/src/messaging.ts
+++ b/packages/extension-ui/src/messaging.ts
@@ -9,7 +9,7 @@ import type { KeyringPairs$Json } from '@polkadot/ui-keyring/types';
 import type { KeypairType } from '@polkadot/util-crypto/types';
 
 import { PORT_EXTENSION } from '@polkadot/extension-base/defaults';
-import {getLatestMetaFromServer, getLatestTypesFromServer, metadataExpand} from '@polkadot/extension-chains';
+import { getLatestMetaFromServer, getLatestTypesFromServer, metadataExpand } from '@polkadot/extension-chains';
 import chrome from '@polkadot/extension-inject/chrome';
 import { MetadataDef } from '@polkadot/extension-inject/types';
 

--- a/packages/extension-ui/src/messaging.ts
+++ b/packages/extension-ui/src/messaging.ts
@@ -158,17 +158,13 @@ export async function getMetadata (genesisHash?: string | null, specVersion?: BN
     // when spec version is not the latest, fetch latest and updated state with latest metadata
     if (specVersion && !specVersion.eqn(specVersionInState)) {
       const metaDataInfo = getLatestMetaFromServer(genesisHash);
-      const additionalTypes = getLatestTypesFromServer();
+      const additionalTypes = getLatestTypesFromServer(genesisHash);
       if (metaDataInfo) {
         def.specVersion = metaDataInfo.specVersion;
         def.metaCalls = metaDataInfo.metaCalls;
-        const newTypes = additionalTypes ? additionalTypes.types : {};
-        const oldTypes = def.types;
-        def.types = {...oldTypes, ...newTypes};
-        const newUserExtensions = additionalTypes ? additionalTypes.userExtensions : undefined;
-        if (newUserExtensions) {
-          const oldUserExtensions = def.userExtensions;
-          def.userExtensions = {...oldUserExtensions, ...newUserExtensions};
+        if (additionalTypes) {
+          def.types = additionalTypes.types;
+          def.userExtensions = additionalTypes.userExtensions;
         }
         await sendMessage('pri(metadata.set)', def);
       }

--- a/packages/extension-ui/src/messaging.ts
+++ b/packages/extension-ui/src/messaging.ts
@@ -9,13 +9,13 @@ import type { KeyringPairs$Json } from '@polkadot/ui-keyring/types';
 import type { KeypairType } from '@polkadot/util-crypto/types';
 
 import { PORT_EXTENSION } from '@polkadot/extension-base/defaults';
-import {getLatestMetaFromServer, getLatestTypesFromServer, metadataExpand} from '@polkadot/extension-chains';
+import {getLatestMetaFromServer, metadataExpand} from '@polkadot/extension-chains';
 import chrome from '@polkadot/extension-inject/chrome';
 import { MetadataDef } from '@polkadot/extension-inject/types';
 
 import allChains from './util/chains';
 import { getSavedMeta, setSavedMeta } from './MetadataCache';
-import BN from "bn.js";
+import BN from 'bn.js';
 
 interface Handler {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -159,10 +159,10 @@ export async function getMetadata (genesisHash?: string | null, specVersion?: BN
     if (specVersion && !specVersion.eqn(specVersionInState)) {
       console.log('Spec versions are different - update meta')
       const metaDataInfo = getLatestMetaFromServer(genesisHash);
-      const newTypes = getLatestTypesFromServer();
       if (metaDataInfo) {
         def.specVersion = metaDataInfo.specVersion;
         def.metaCalls = metaDataInfo.metaCalls;
+        const newTypes = metaDataInfo.types;
         const oldTypes = def.types;
         def.types = {...oldTypes, ...newTypes};
         await sendMessage('pri(metadata.set)', def);


### PR DESCRIPTION
Closes https://github.com/cennznet/extension/issues/5.

https://hackmd.io/8mjLPRN5Rqu6cmyQ3PNEjQ

When extension user tries to use new runtime module method via extension this PR would decode the method call and type definition so that user will not have to take care of updating metadata in extension, every time a new spec version( runtime module is added) is released...  For a chain and spec version, we will request data from GitHub files once and store it for future use (this will happen only when user uses that chain).
This PR assumes two things and is right now used with test1 branch on cennznet/api (https://github.com/cennznet/api.js/tree/test1) and (https://github.com/cennznet/cennznet/tree/feature/snake-runtime) on node

Assumptions:

1. For all the chain, we will always keep static metadata updated in the file - https://github.com/cennznet/api.js/blob/test1/packages/api/src/staticMetadata.ts when we release new api version.
2. Whenever new types are added for a new runtime module... Expect a file (https://github.com/cennznet/api.js/blob/test1/packages/types/src/runtimeModuleTypes.ts) to be updated with those definition...

<img width="1318" alt="Screen Shot 2021-07-05 at 10 58 16 AM" src="https://user-images.githubusercontent.com/29415595/124401828-e8b9ae00-dd7f-11eb-96d6-8cb8152cc52f.png">
