### PR TITLE
Make pop-up visible when signing tx for first time on ff

### DIFF
--- a/packages/extension-base/src/background/handlers/Extension.ts
+++ b/packages/extension-base/src/background/handlers/Extension.ts
@@ -488,7 +488,7 @@ export default class Extension {
   }
 
   private windowOpen (path: AllowedPath): boolean {
-    const url = `${chrome.extension.getURL('index.html')}#${path}`;
+    const url = `${chrome.runtime.getURL('index.html')}#${path}`;
 
     if (!ALLOWED_PATH.includes(path)) {
       console.error('Not allowed to open the url:', url);

--- a/packages/extension-inject/src/chrome.ts
+++ b/packages/extension-inject/src/chrome.ts
@@ -8,3 +8,15 @@ const extension = typeof chrome !== 'undefined'
     : null;
 
 export default extension as typeof chrome;
+
+export function getBrowser() {
+  if (typeof chrome !== "undefined") {
+    if (typeof browser !== "undefined") {
+      return "Firefox";
+    } else {
+      return "Chrome";
+    }
+  } else {
+    return "Edge";
+  }
+}


### PR DESCRIPTION
Closes https://github.com/cennznet/extension/issues/12

Replaced deprecated browser.extension.getURL to browser.runtime.getURL as per
 https://developer.chrome.com/docs/extensions/reference/extension/#method-getURL

In firefox - when creating pop-up the top dimension is ignored and the screen is in visible (https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/windows/create). Fixed it using browser.windows.update()

https://user-images.githubusercontent.com/29415595/127429437-1e6128a4-30f8-4af3-a1c3-0ec9e5397544.mov

Tested on firefox and Chrome... works well