### PR TITLE
add uncover link to show tx history to extension users

### DIFF
--- a/packages/extension-ui/src/Popup/Accounts/Account.tsx
+++ b/packages/extension-ui/src/Popup/Accounts/Account.tsx
@@ -71,6 +71,12 @@ function Account ({ address, className, genesisHash, isExternal, isHardware, isH
           {t<string>('Derive New Account')}
         </Link>
       )}
+      <a className='menuItem'
+        href={`https://uncoverexplorer.com/account/${address}`}
+        target="_blank"
+      >
+        {t<string>('View on UNcover')}
+      </a>
       <MenuDivider />
       {!isExternal && (
         <Link

--- a/packages/extension/public/locales/en/translation.json
+++ b/packages/extension/public/locales/en/translation.json
@@ -158,5 +158,6 @@
   "Export all accounts": "",
   "All account": "",
   "password for encrypting all accounts": "",
-  "I want to export all my accounts": ""
+  "I want to export all my accounts": "",
+  "View on UNcover": ""
 }


### PR DESCRIPTION
<img width="580" alt="Screen Shot 2021-08-02 at 10 56 12 AM" src="https://user-images.githubusercontent.com/29415595/127787879-6142e504-6079-404f-80cd-c77985d7cd82.png">

Once this PR is merged, I will try publishing on chrome.