### PR TITLE
uncover nikau link

### DIFF
--- a/packages/extension-ui/package.json
+++ b/packages/extension-ui/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@cennznet/extension-base": "^0.38.2",
+    "@cennznet/extension-chains": "^0.38.2",
     "@cennznet/extension-inject": "^0.38.2",
     "@fortawesome/fontawesome-svg-core": "^1.2.35",
     "@fortawesome/free-brands-svg-icons": "^5.15.3",

--- a/packages/extension-ui/src/Popup/Accounts/Account.tsx
+++ b/packages/extension-ui/src/Popup/Accounts/Account.tsx
@@ -14,6 +14,7 @@ import useGenesisHashOptions from '../../hooks/useGenesisHashOptions';
 import useTranslation from '../../hooks/useTranslation';
 import { editAccount, tieAccount } from '../../messaging';
 import { Name } from '../../partials';
+import defaultConfig from "@cennznet/extension-chains/config";
 
 interface Props extends AccountJson {
   className?: string;
@@ -30,6 +31,7 @@ function Account ({ address, className, genesisHash, isExternal, isHardware, isH
   const [{ isEditing, toggleActions }, setEditing] = useState<EditState>({ isEditing: false, toggleActions: 0 });
   const [editedName, setName] = useState<string | undefined | null>(name);
   const genesisOptions = useGenesisHashOptions();
+  const nikauChain = defaultConfig.CENNZNetChain.find(blkChain => blkChain.chain === 'CENNZnet Nikau');
 
   const _onChangeGenesis = useCallback(
     (genesisHash?: string | null): void => {
@@ -72,16 +74,10 @@ function Account ({ address, className, genesisHash, isExternal, isHardware, isH
         </Link>
       )}
       <a className='menuItem'
-        href={`https://uncoverexplorer.com/account/${address}`}
-        target="_blank"
-      >
-        {t<string>('View on UNcover (Azalea)')}
-      </a>
-      <a className='menuItem'
-         href={`https://uncoverexplorer.com/account/${address}?network=Nikau`}
+         href={genesisHash === nikauChain?.genesisHash ? `https://uncoverexplorer.com/account/${address}?network=Nikau` : `https://uncoverexplorer.com/account/${address}`}
          target="_blank"
       >
-        {t<string>('View on UNcover (Nikau)')}
+        {t<string>('View on UNcover')}
       </a>
       <MenuDivider />
       {!isExternal && (

--- a/packages/extension-ui/src/Popup/Accounts/Account.tsx
+++ b/packages/extension-ui/src/Popup/Accounts/Account.tsx
@@ -75,7 +75,13 @@ function Account ({ address, className, genesisHash, isExternal, isHardware, isH
         href={`https://uncoverexplorer.com/account/${address}`}
         target="_blank"
       >
-        {t<string>('View on UNcover')}
+        {t<string>('View on UNcover (Azalea)')}
+      </a>
+      <a className='menuItem'
+         href={`https://uncoverexplorer.com/account/${address}?network=Nikau`}
+         target="_blank"
+      >
+        {t<string>('View on UNcover (Nikau)')}
       </a>
       <MenuDivider />
       {!isExternal && (

--- a/packages/extension/public/locales/en/translation.json
+++ b/packages/extension/public/locales/en/translation.json
@@ -160,6 +160,4 @@
   "password for encrypting all accounts": "",
   "I want to export all my accounts": "",
   "View on UNcover": "",
-  "View on UNcover (Azalea)": "",
-  "View on UNcover (Nikau)": ""
 }

--- a/packages/extension/public/locales/en/translation.json
+++ b/packages/extension/public/locales/en/translation.json
@@ -159,5 +159,7 @@
   "All account": "",
   "password for encrypting all accounts": "",
   "I want to export all my accounts": "",
-  "View on UNcover": ""
+  "View on UNcover": "",
+  "View on UNcover (Azalea)": "",
+  "View on UNcover (Nikau)": ""
 }

--- a/packages/extension/public/locales/en/translation.json
+++ b/packages/extension/public/locales/en/translation.json
@@ -159,5 +159,5 @@
   "All account": "",
   "password for encrypting all accounts": "",
   "I want to export all my accounts": "",
-  "View on UNcover": "",
+  "View on UNcover": ""
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1361,12 +1361,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cennznet/extension-base@^0.38.1, @cennznet/extension-base@workspace:packages/extension-base":
+"@cennznet/extension-base@^0.38.2, @cennznet/extension-base@workspace:packages/extension-base":
   version: 0.0.0-use.local
   resolution: "@cennznet/extension-base@workspace:packages/extension-base"
   dependencies:
     "@babel/runtime": ^7.13.10
-    "@cennznet/extension-inject": ^0.38.1
+    "@cennznet/extension-inject": ^0.38.2
     "@polkadot/api": ^4.4.1
     "@polkadot/keyring": ^6.0.5
     "@polkadot/phishing": ^0.6.72
@@ -1374,7 +1374,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@cennznet/extension-chains@workspace:packages/extension-chains":
+"@cennznet/extension-chains@^0.38.2, @cennznet/extension-chains@workspace:packages/extension-chains":
   version: 0.0.0-use.local
   resolution: "@cennznet/extension-chains@workspace:packages/extension-chains"
   dependencies:
@@ -1390,7 +1390,7 @@ __metadata:
   resolution: "@cennznet/extension-dapp@workspace:packages/extension-dapp"
   dependencies:
     "@babel/runtime": ^7.13.10
-    "@cennznet/extension-inject": ^0.38.1
+    "@cennznet/extension-inject": ^0.38.2
     "@polkadot/util": ^6.0.5
     "@polkadot/util-crypto": ^6.0.5
   peerDependencies:
@@ -1400,7 +1400,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@cennznet/extension-inject@^0.38.1, @cennznet/extension-inject@workspace:packages/extension-inject":
+"@cennznet/extension-inject@^0.38.2, @cennznet/extension-inject@workspace:packages/extension-inject":
   version: 0.0.0-use.local
   resolution: "@cennznet/extension-inject@workspace:packages/extension-inject"
   dependencies:
@@ -1412,13 +1412,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@cennznet/extension-ui@^0.38.1, @cennznet/extension-ui@workspace:packages/extension-ui":
+"@cennznet/extension-ui@^0.38.2, @cennznet/extension-ui@workspace:packages/extension-ui":
   version: 0.0.0-use.local
   resolution: "@cennznet/extension-ui@workspace:packages/extension-ui"
   dependencies:
     "@babel/runtime": ^7.13.10
-    "@cennznet/extension-base": ^0.38.1
-    "@cennznet/extension-inject": ^0.38.1
+    "@cennznet/extension-base": ^0.38.2
+    "@cennznet/extension-chains": ^0.38.2
+    "@cennznet/extension-inject": ^0.38.2
     "@fortawesome/fontawesome-svg-core": ^1.2.35
     "@fortawesome/free-brands-svg-icons": ^5.15.3
     "@fortawesome/free-regular-svg-icons": ^5.15.3
@@ -1461,9 +1462,9 @@ __metadata:
   resolution: "@cennznet/extension@workspace:packages/extension"
   dependencies:
     "@babel/runtime": ^7.13.10
-    "@cennznet/extension-base": ^0.38.1
-    "@cennznet/extension-inject": ^0.38.1
-    "@cennznet/extension-ui": ^0.38.1
+    "@cennznet/extension-base": ^0.38.2
+    "@cennznet/extension-inject": ^0.38.2
+    "@cennznet/extension-ui": ^0.38.2
     "@polkadot/dev": ^0.62.7
     babel-loader: ^8.2.2
     browser-resolve: ^2.0.0


### PR DESCRIPTION
Motivation - DApp user wanting to test on Nikau would like to have a link from extension to uncover (which by default goes to Azalea) and another link of uncover Nikau support..


https://user-images.githubusercontent.com/29415595/127959589-f0eb7b15-0757-4396-8b6b-2d0bed6262fe.mov

Let me know your thoughts